### PR TITLE
Add configurable AI model selection and improve output handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,9 +97,12 @@ Add these secrets to your repository:
 | `ai_provider` | No | AI provider to use (openai or claude) | openai |
 | `openai_api_key` | Yes* | OpenAI API key (required if ai_provider is openai) | - |
 | `anthropic_api_key` | Yes* | Anthropic API key (required if ai_provider is claude) | - |
+| `ai_model` | No | Model name to override the provider default (e.g. `claude-haiku-4-5-20251001`, `gpt-4o-mini`) | provider default |
 | `days_back` | No | Number of days to look back for PRs | 7 |
 
 *Either `openai_api_key` OR `anthropic_api_key` is required, depending on the chosen provider.
+
+When `ai_model` is omitted, each provider falls back to its default: `gpt-4o-mini` for OpenAI and `claude-haiku-4-5-20251001` for Claude.
 
 ## Action Outputs
 

--- a/action.yml
+++ b/action.yml
@@ -24,6 +24,10 @@ inputs:
   anthropic_api_key:
     description: 'Anthropic API key (required if ai_provider is claude)'
     required: false
+  ai_model:
+    description: 'Optional model name to override the provider default (e.g. claude-haiku-4-5-20251001, gpt-4o-mini)'
+    required: false
+    default: ''
   days_back:
     description: 'Number of days to look back for PRs'
     required: false
@@ -66,16 +70,23 @@ runs:
         AI_PROVIDER: ${{ inputs.ai_provider }}
         OPENAI_API_KEY: ${{ inputs.openai_api_key }}
         ANTHROPIC_API_KEY: ${{ inputs.anthropic_api_key }}
+        AI_MODEL: ${{ inputs.ai_model }}
       run: |
         python release-notes-generator-action/scripts/generate_release_notes.py \
           --repos "${{ inputs.repos }}" \
           --days-back ${{ inputs.days_back }}
         
-        # Read the generated message and timestamp
+        # Read the generated message and write it to the step output.
+        # Use a unique random delimiter so the generated content can never
+        # collide with the heredoc terminator (the static "EOF" delimiter
+        # broke when the AI output contained a line equal to "EOF").
         if [ -f "generated_message.txt" ]; then
-          echo "message<<EOF" >> $GITHUB_OUTPUT
-          cat generated_message.txt >> $GITHUB_OUTPUT
-          echo "EOF" >> $GITHUB_OUTPUT
+          delimiter="ghadelimiter_$(openssl rand -hex 16)"
+          {
+            echo "message<<${delimiter}"
+            cat generated_message.txt
+            echo "${delimiter}"
+          } >> "$GITHUB_OUTPUT"
         fi
         
     - name: Upload artifacts

--- a/scripts/ai_provider.py
+++ b/scripts/ai_provider.py
@@ -100,7 +100,7 @@ class OpenAIProvider(AIProvider):
 class ClaudeProvider(AIProvider):
     """Claude API provider implementation."""
     
-    def __init__(self, api_key: str, model: str = "claude-3-haiku-20240307"):
+    def __init__(self, api_key: str, model: str = "claude-haiku-4-5-20251001"):
         """
         Initialize Claude provider.
         
@@ -178,7 +178,7 @@ def create_ai_provider(provider: str, api_key: str, model: Optional[str] = None)
         model = model or "gpt-4o-mini"
         return OpenAIProvider(api_key, model)
     elif provider.lower() == 'claude':
-        model = model or "claude-3-haiku-20240307"
+        model = model or "claude-haiku-4-5-20251001"
         return ClaudeProvider(api_key, model)
     else:
         raise ValueError(f"Unsupported AI provider: {provider}. Supported providers: openai, claude") 

--- a/scripts/generate_release_notes.py
+++ b/scripts/generate_release_notes.py
@@ -513,6 +513,7 @@ def main():
     slack_bot_token = os.getenv("SLACK_BOT_TOKEN")
     slack_channel = os.getenv("SLACK_CHANNEL")
     ai_provider = os.getenv("AI_PROVIDER", "openai").lower()
+    ai_model = os.getenv("AI_MODEL") or None
     openai_api_key = os.getenv("OPENAI_API_KEY")
     anthropic_api_key = os.getenv("ANTHROPIC_API_KEY")
     github_token = os.getenv("GITHUB_TOKEN")
@@ -560,7 +561,8 @@ def main():
             slack_channel=slack_channel,
             ai_provider=ai_provider,
             ai_api_key=ai_api_key,
-            github_token=github_token
+            github_token=github_token,
+            ai_model=ai_model
         )
         
         # Generate release notes


### PR DESCRIPTION
## Summary
This PR adds support for overriding the default AI model used by the action, allowing users to specify custom models for both OpenAI and Claude providers. It also improves the reliability of GitHub Actions output handling by using a random delimiter instead of a static one.

## Key Changes

- **Added `ai_model` input parameter**: Users can now optionally specify a custom model name (e.g., `claude-haiku-4-5-20251001`, `gpt-4o-mini`) to override provider defaults
- **Updated default Claude model**: Changed from `claude-3-haiku-20240307` to `claude-haiku-4-5-20251001` across all provider implementations
- **Improved GitHub Actions output handling**: Replaced static "EOF" delimiter with a random delimiter (`ghadelimiter_<random-hex>`) to prevent collisions when AI-generated content contains "EOF"
- **Updated documentation**: Added `ai_model` parameter to README with examples and fallback behavior explanation

## Implementation Details

- The `ai_model` environment variable is now passed through the action workflow and read by the release notes generator script
- The `create_ai_provider()` function respects the optional model parameter, falling back to provider defaults when not specified
- The output delimiter is generated using `openssl rand -hex 16` to ensure uniqueness and prevent heredoc terminator collisions
- All changes maintain backward compatibility - the `ai_model` parameter is optional with sensible defaults

https://claude.ai/code/session_01KewfYNQSuHQHrZycauZTPm