### PR TITLE
Fix GitHub Actions output delimiter handling for release notes

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -85,6 +85,11 @@ runs:
           {
             echo "message<<${delimiter}"
             cat generated_message.txt
+            # Ensure the closing delimiter starts on its own line even when
+            # the generated file has no trailing newline; otherwise it gets
+            # glued onto the last content line and GitHub reports
+            # "Matching delimiter not found".
+            [ -n "$(tail -c1 generated_message.txt)" ] && echo ""
             echo "${delimiter}"
           } >> "$GITHUB_OUTPUT"
         fi

--- a/scripts/generate_release_notes.py
+++ b/scripts/generate_release_notes.py
@@ -493,9 +493,11 @@ Create user-facing release notes following the format and guidelines above."""
             # Post to Slack
             self.post_to_slack(full_message, date_range)
             
-            # Save message to file for action output
+            # Save message to file for action output. Write a trailing
+            # newline so the action's $GITHUB_OUTPUT heredoc delimiter always
+            # lands on its own line.
             with open("generated_message.txt", "w") as f:
-                f.write(full_message)
+                f.write(full_message + "\n")
             
             logger.info("Release notes generation completed successfully")
         else:


### PR DESCRIPTION
## Summary
Fixed an issue where the release notes message output to GitHub Actions could cause the `$GITHUB_OUTPUT` heredoc delimiter to be incorrectly parsed, resulting in "Matching delimiter not found" errors.

## Key Changes
- **scripts/generate_release_notes.py**: Added a trailing newline when writing the generated message to file, ensuring the output always ends with a newline character
- **action.yml**: Added a check to echo an additional newline if the generated file doesn't already end with one, guaranteeing the closing delimiter always appears on its own line

## Implementation Details
The fix addresses a GitHub Actions limitation where heredoc delimiters must appear on their own line. By ensuring the generated message file always has a trailing newline, we prevent the closing delimiter from being concatenated to the last line of content, which would cause GitHub to fail parsing the output variable.

The dual approach (writing a newline in the Python script and checking in the shell) provides defense-in-depth to handle edge cases where the message might not end with a newline.

https://claude.ai/code/session_01KewfYNQSuHQHrZycauZTPm